### PR TITLE
Add SDK2 appinfo for legacy Pebble (Aplite) and refresh layout after notifications

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -1,0 +1,98 @@
+{
+  "uuid": "b8c0b2a6-2a7a-4d9e-8a1a-3f4c7b4a9e10",
+  "shortName": "supercgm-ns",
+  "longName": "Nightscout Supercgm",
+  "companyName": "sgitaize",
+  "versionLabel": "1.3",
+  "sdkVersion": "2",
+  "watchapp": {
+    "watchface": true
+  },
+  "capabilities": [
+    "configurable",
+    "location",
+    "health"
+  ],
+  "appKeys": {
+    "ROW1_TYPE": 0,
+    "ROW2_TYPE": 1,
+    "ROW3_TYPE": 2,
+    "ROW4_TYPE": 3,
+    "ROW5_TYPE": 4,
+    "ROW1_COLOR": 5,
+    "ROW2_COLOR": 6,
+    "ROW3_COLOR": 7,
+    "ROW4_COLOR": 8,
+    "ROW5_COLOR": 9,
+    "GHOST_COLOR": 10,
+    "SHOW_LEADING_ZERO": 11,
+    "DATE_FORMAT": 12,
+    "WEEKDAY_LANG": 13,
+    "TEMP_UNIT": 14,
+    "BG_URL": 15,
+    "BG_TIMEOUT_MIN": 16,
+    "BG_FETCH_INTERVAL_MIN": 17,
+    "BG_THRESH_LOW": 18,
+    "BG_THRESH_HIGH": 19,
+    "WEATHER_INTERVAL_MIN": 20,
+    "COLOR_LOW": 21,
+    "COLOR_HIGH": 22,
+    "COLOR_IN_RANGE": 23,
+    "REQUEST_WEATHER": 24,
+    "REQUEST_BG": 25,
+    "WEATHER_TEMP": 26,
+    "BG_SGV": 27,
+    "BG_TIMESTAMP": 28,
+    "BG_STATUS": 29,
+    "BG_UNIT": 30,
+    "BG_TREND": 31
+  },
+  "targetPlatforms": [
+    "aplite",
+    "basalt"
+  ],
+  "resources": {
+    "media": [
+      {
+        "type": "font",
+        "name": "FONT_DSEG_30_BOLD",
+        "file": "fonts/DSEG14Classic-Bold.ttf"
+      },
+      {
+        "type": "font",
+        "name": "FONT_DSEG_30_REG",
+        "file": "fonts/DSEG14Classic-Regular.ttf"
+      },
+      {
+        "type": "font",
+        "name": "FONT_DSEG_29_BOLD",
+        "file": "fonts/DSEG14Classic-Bold.ttf"
+      },
+      {
+        "type": "font",
+        "name": "FONT_DSEG_29_REG",
+        "file": "fonts/DSEG14Classic-Regular.ttf"
+      },
+      {
+        "type": "font",
+        "name": "FONT_DSEG_25_BOLD",
+        "file": "fonts/DSEG14Classic-Bold.ttf"
+      },
+      {
+        "type": "font",
+        "name": "FONT_DSEG_25_REG",
+        "file": "fonts/DSEG14Classic-Regular.ttf"
+      },
+      {
+        "type": "font",
+        "name": "FONT_DSEG_26_BOLD",
+        "file": "fonts/DSEG14Classic-Bold.ttf"
+      },
+      {
+        "type": "font",
+        "name": "FONT_DSEG_26_REG",
+        "file": "fonts/DSEG14Classic-Regular.ttf"
+      }
+    ]
+  }
+}

--- a/appinfo.json
+++ b/appinfo.json
@@ -3,7 +3,7 @@
   "shortName": "supercgm-ns",
   "longName": "Nightscout Supercgm",
   "companyName": "sgitaize",
-  "versionLabel": "1.3",
+  "versionLabel": "1.5",
   "sdkVersion": "2",
   "watchapp": {
     "watchface": true

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "pebble": {
     "displayName": "supercgm-ns",
     "uuid": "b8c0b2a6-2a7a-4d9e-8a1a-3f4c7b4a9e10",
-  "sdkVersion": "3",
+    "sdkVersion": "3",
     "projectType": "native",
-  "enableMultiJS": true,
-  "screenshot": "resources/screenshot/screenshotsupercgm.png",
+    "enableMultiJS": true,
+    "screenshot": "resources/screenshot/screenshotsupercgm.png",
     "resources": {
       "media": [
         {
@@ -72,26 +72,52 @@
       ]
     },
     "messageKeys": [
-      "ROW1_TYPE", "ROW2_TYPE", "ROW3_TYPE", "ROW4_TYPE", "ROW5_TYPE",
-      "ROW1_COLOR", "ROW2_COLOR", "ROW3_COLOR", "ROW4_COLOR", "ROW5_COLOR",
+      "ROW1_TYPE",
+      "ROW2_TYPE",
+      "ROW3_TYPE",
+      "ROW4_TYPE",
+      "ROW5_TYPE",
+      "ROW1_COLOR",
+      "ROW2_COLOR",
+      "ROW3_COLOR",
+      "ROW4_COLOR",
+      "ROW5_COLOR",
       "GHOST_COLOR",
       "SHOW_LEADING_ZERO",
-      "DATE_FORMAT", "WEEKDAY_LANG", "TEMP_UNIT",
-  "BG_URL", "BG_TIMEOUT_MIN", "BG_FETCH_INTERVAL_MIN", "BG_THRESH_LOW", "BG_THRESH_HIGH",
+      "DATE_FORMAT",
+      "WEEKDAY_LANG",
+      "TEMP_UNIT",
+      "BG_URL",
+      "BG_TIMEOUT_MIN",
+      "BG_FETCH_INTERVAL_MIN",
+      "BG_THRESH_LOW",
+      "BG_THRESH_HIGH",
       "WEATHER_INTERVAL_MIN",
-      "COLOR_LOW", "COLOR_HIGH", "COLOR_IN_RANGE",
-      "REQUEST_WEATHER", "REQUEST_BG",
+      "COLOR_LOW",
+      "COLOR_HIGH",
+      "COLOR_IN_RANGE",
+      "REQUEST_WEATHER",
+      "REQUEST_BG",
       "WEATHER_TEMP",
-      "BG_SGV", "BG_TIMESTAMP", "BG_STATUS", "BG_UNIT", "BG_TREND"
+      "BG_SGV",
+      "BG_TIMESTAMP",
+      "BG_STATUS",
+      "BG_UNIT",
+      "BG_TREND"
     ],
     "capabilities": [
       "configurable",
       "location",
       "health"
     ],
-  "watchapp": {
+    "watchapp": {
       "watchface": true
     },
-  "targetPlatforms": ["aplite","basalt","chalk","diorite"]
+    "targetPlatforms": [
+      "aplite",
+      "basalt",
+      "chalk",
+      "diorite"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Nightscout Supercgm",
-  "version": "1.3",
+  "version": "1.5",
   "description": "Watchface with 5 flexible rows: time, date, weekday, battery, weather, Nightscout BG, steps.",
   "author": "sgitaize",
   "license": "MIT",

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,9 @@ static GColor s_bg_trend_color;
 static Layer *s_weather_deg_layer;
 static GColor s_weather_deg_color;
 static char s_weather_unit_char = 0; // 'C' or 'F'
+#if defined(PBL_PLATFORM_APLITE)
+static AppTimer *s_redraw_timer;
+#endif
 // Persistent 1-char + NUL buffers for each foreground slot
 static char s_slot_text[ROWS][5][2];
 static GFont s_font_dseg_30;       // Bold (foreground)
@@ -99,6 +102,10 @@ static void update_heart_rate(void);
 static GRect get_layout_bounds(void);
 static void main_window_appear(Window *window);
 static void app_focus_handler(bool in_focus);
+static void force_redraw_layers(void);
+#if defined(PBL_PLATFORM_APLITE)
+static void periodic_redraw(void *context);
+#endif
 
 #if PBL_API_EXISTS(unobstructed_area_service_subscribe)
 static void unobstructed_change(AnimationProgress progress, void *context);
@@ -805,7 +812,37 @@ static void app_focus_handler(bool in_focus) {
   }
   layout_rows();
   draw_all_rows();
+  force_redraw_layers();
 }
+
+static void force_redraw_layers(void) {
+  for (int i = 0; i < ROWS; i++) {
+    for (int c = 0; c < 5; c++) {
+      if (s_ghost_layers[i][c]) {
+        layer_mark_dirty(text_layer_get_layer(s_ghost_layers[i][c]));
+      }
+      if (s_ghost_hatch_layers[i][c]) {
+        layer_mark_dirty(s_ghost_hatch_layers[i][c]);
+      }
+      if (s_digit_layers[i][c]) {
+        layer_mark_dirty(text_layer_get_layer(s_digit_layers[i][c]));
+      }
+    }
+  }
+  if (s_bg_trend_layer) {
+    layer_mark_dirty(s_bg_trend_layer);
+  }
+  if (s_weather_deg_layer) {
+    layer_mark_dirty(s_weather_deg_layer);
+  }
+}
+
+#if defined(PBL_PLATFORM_APLITE)
+static void periodic_redraw(void *context) {
+  force_redraw_layers();
+  s_redraw_timer = app_timer_register(1000, periodic_redraw, NULL);
+}
+#endif
 
 static void main_window_unload(Window *window) {
   for (int i = 0; i < ROWS; i++) {
@@ -916,6 +953,9 @@ static void init(void) {
   }, NULL);
 #endif
   app_focus_service_subscribe(app_focus_handler);
+#if defined(PBL_PLATFORM_APLITE)
+  s_redraw_timer = app_timer_register(1000, periodic_redraw, NULL);
+#endif
 
   // Messaging
   app_message_register_inbox_received(inbox_received_callback);
@@ -936,6 +976,12 @@ static void deinit(void) {
   unobstructed_area_service_unsubscribe();
 #endif
   app_focus_service_unsubscribe();
+#if defined(PBL_PLATFORM_APLITE)
+  if (s_redraw_timer) {
+    app_timer_cancel(s_redraw_timer);
+    s_redraw_timer = NULL;
+  }
+#endif
 
   fonts_unload_custom_font(s_font_dseg_30);
   if (s_font_dseg_30_reg) fonts_unload_custom_font(s_font_dseg_30_reg);

--- a/src/main.c
+++ b/src/main.c
@@ -98,6 +98,7 @@ static void weather_deg_update_proc(Layer *layer, GContext *ctx);
 static void update_heart_rate(void);
 static GRect get_layout_bounds(void);
 static void main_window_appear(Window *window);
+static void app_focus_handler(bool in_focus);
 
 #if PBL_API_EXISTS(unobstructed_area_service_subscribe)
 static void unobstructed_change(AnimationProgress progress, void *context);
@@ -798,6 +799,14 @@ static void main_window_appear(Window *window) {
   draw_all_rows();
 }
 
+static void app_focus_handler(bool in_focus) {
+  if (!in_focus) {
+    return;
+  }
+  layout_rows();
+  draw_all_rows();
+}
+
 static void main_window_unload(Window *window) {
   for (int i = 0; i < ROWS; i++) {
     for (int c = 0; c < 5; c++) {
@@ -906,6 +915,7 @@ static void init(void) {
     .did_change = unobstructed_did_change
   }, NULL);
 #endif
+  app_focus_service_subscribe(app_focus_handler);
 
   // Messaging
   app_message_register_inbox_received(inbox_received_callback);
@@ -925,6 +935,7 @@ static void deinit(void) {
 #if PBL_API_EXISTS(unobstructed_area_service_unsubscribe)
   unobstructed_area_service_unsubscribe();
 #endif
+  app_focus_service_unsubscribe();
 
   fonts_unload_custom_font(s_font_dseg_30);
   if (s_font_dseg_30_reg) fonts_unload_custom_font(s_font_dseg_30_reg);

--- a/src/main.c
+++ b/src/main.c
@@ -32,9 +32,6 @@ static GColor s_bg_trend_color;
 static Layer *s_weather_deg_layer;
 static GColor s_weather_deg_color;
 static char s_weather_unit_char = 0; // 'C' or 'F'
-#if defined(PBL_PLATFORM_APLITE)
-static AppTimer *s_redraw_timer;
-#endif
 // Persistent 1-char + NUL buffers for each foreground slot
 static char s_slot_text[ROWS][5][2];
 static GFont s_font_dseg_30;       // Bold (foreground)
@@ -103,9 +100,6 @@ static GRect get_layout_bounds(void);
 static void main_window_appear(Window *window);
 static void app_focus_handler(bool in_focus);
 static void force_redraw_layers(void);
-#if defined(PBL_PLATFORM_APLITE)
-static void periodic_redraw(void *context);
-#endif
 
 #if PBL_API_EXISTS(unobstructed_area_service_subscribe)
 static void unobstructed_change(AnimationProgress progress, void *context);
@@ -837,13 +831,6 @@ static void force_redraw_layers(void) {
   }
 }
 
-#if defined(PBL_PLATFORM_APLITE)
-static void periodic_redraw(void *context) {
-  force_redraw_layers();
-  s_redraw_timer = app_timer_register(1000, periodic_redraw, NULL);
-}
-#endif
-
 static void main_window_unload(Window *window) {
   for (int i = 0; i < ROWS; i++) {
     for (int c = 0; c < 5; c++) {
@@ -953,9 +940,6 @@ static void init(void) {
   }, NULL);
 #endif
   app_focus_service_subscribe(app_focus_handler);
-#if defined(PBL_PLATFORM_APLITE)
-  s_redraw_timer = app_timer_register(1000, periodic_redraw, NULL);
-#endif
 
   // Messaging
   app_message_register_inbox_received(inbox_received_callback);
@@ -976,12 +960,6 @@ static void deinit(void) {
   unobstructed_area_service_unsubscribe();
 #endif
   app_focus_service_unsubscribe();
-#if defined(PBL_PLATFORM_APLITE)
-  if (s_redraw_timer) {
-    app_timer_cancel(s_redraw_timer);
-    s_redraw_timer = NULL;
-  }
-#endif
 
   fonts_unload_custom_font(s_font_dseg_30);
   if (s_font_dseg_30_reg) fonts_unload_custom_font(s_font_dseg_30_reg);


### PR DESCRIPTION
### Motivation
- The Rebble/Pebble store reported the watchface as incompatible with older Pebble firmware (e.g. Pebble Steel / Aplite), so a legacy SDK2 manifest is required to restore compatibility. 
- Notification banners/unobstructed-area transitions on older devices can shift the usable screen area and cause rows or overlays to be clipped or mispositioned, so layout must respect the unobstructed area. 
- `package.json` contained formatting/structure issues that could prevent proper metadata parsing by legacy tooling and should be normalized.

### Description
- Added a legacy manifest `appinfo.json` with `sdkVersion: "2"`, `appKeys` and minimal `resources` and `targetPlatforms` (`"aplite"`, `"basalt"`) to enable installation on classic Pebble firmwares. 
- Fixed and reformatted `package.json` so Pebble/Rebble tooling can parse `pebble` metadata and preserved `targetPlatforms` including `aplite` for build tooling. 
- Implemented `get_layout_bounds()` and switched `layout_rows()`/overlay positioning in `draw_all_rows()` to use the unobstructed bounds origin/size when available (`unobstructed_area_service_get_unobstructed_bounds()`). 
- Added `main_window_appear()` and unobstructed-area handlers (`unobstructed_change()` / `unobstructed_did_change()`), and subscribed/unsubscribed to `unobstructed_area_service` in `init()`/`deinit()` so the watchface relayouts and redraws on notification transitions; relevant changes are in `src/main.c` (`get_layout_bounds()`, `main_window_appear()`, handler wiring and usage). 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c62b409d0833289533d1835d86faf)