### PR TITLE
feat: v2.2 — fix mmol display, add auth token, BG age timestamp, Y-ax…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Nightscout Supercgm",
-  "version": "2.1",
+  "version": "2.2",
   "description": "Watchface with 5 flexible rows: time, date, weekday, battery, weather, Nightscout BG, steps.",
   "author": "sgitaize",
   "license": "MIT",

--- a/src/js/pebble-js-app.js
+++ b/src/js/pebble-js-app.js
@@ -6,6 +6,7 @@ var keys = require('message_keys');
   var config = {
     weatherApi: 'https://api.open-meteo.com/v1/forecast',
     bgUrl: null,
+    authToken: null,
     bgTimeoutMin: 20,
     low: 80,
     high: 180,
@@ -166,8 +167,9 @@ var keys = require('message_keys');
   'COLOR_HIGH': hexToInt(quantize(config.colors.high)),
   'COLOR_IN_RANGE': hexToInt(quantize(config.colors.in)),
   'GHOST_COLOR': hexToInt(quantize(config.colors.ghost)),
-      'BG_THRESH_LOW': config.low,
-      'BG_THRESH_HIGH': config.high,
+      // Thresholds are stored in the configured unit; send ×10 for mmol so C compares in same unit as sgv
+      'BG_THRESH_LOW':  config.bgUnit === 'mmol' ? Math.round((parseFloat(config.low)  || 0) * 10) : Math.round(parseFloat(config.low)  || 80),
+      'BG_THRESH_HIGH': config.bgUnit === 'mmol' ? Math.round((parseFloat(config.high) || 0) * 10) : Math.round(parseFloat(config.high) || 180),
       'DISPLAY_BG_COLOR': hexToInt(quantize(bgColorHex))
     };
     // 3) Basics
@@ -400,7 +402,12 @@ var keys = require('message_keys');
       planNextBGFetch(null);
       return;
     }
-    var url = config.bgUrl.replace(/\/$/, '') + '/pebble';
+    var baseUrl = config.bgUrl.replace(/\/$/, '');
+    // If bgUrl already contains /pebble (e.g. with ?token= workaround), use as-is
+    var url = (baseUrl.indexOf('/pebble') >= 0) ? baseUrl : baseUrl + '/pebble';
+    if (config.authToken && url.indexOf('token=') < 0) {
+      url += (url.indexOf('?') >= 0 ? '&' : '?') + 'token=' + encodeURIComponent(config.authToken);
+    }
     var req = new XMLHttpRequest();
     req.onload = function() {
       try {
@@ -411,25 +418,48 @@ var keys = require('message_keys');
         var json = JSON.parse(this.responseText);
         // responses can vary; handle Nightscout /pebble (json.bgs[0]) and others
         var sgv = null, ts = null, trend = null, bgDelta = null, serverNow = null;
+
+        // Parse SGV: auto-detect if NS sends mmol (float < 40) or mg/dL (integer >= 40).
+        // When bgUnit is mmol, always send mmol×10 so C can display "X.Y" without conversion.
+        function parseSgv(raw) {
+          var f = parseFloat(raw);
+          if (!isFinite(f) || f <= 0) return NaN;
+          if (config.bgUnit === 'mmol') {
+            return f < 40 ? Math.round(f * 10) : Math.round(f * 10 / 18);
+          } else {
+            return f < 40 ? Math.round(f * 18) : Math.round(f);
+          }
+        }
+        function parseDelta(raw) {
+          var f = parseFloat(raw);
+          if (!isFinite(f)) return NaN;
+          if (config.bgUnit === 'mmol') {
+            return Math.abs(f) < 30 ? Math.round(f * 10) : Math.round(f * 10 / 18);
+          } else {
+            return Math.abs(f) < 30 && String(raw).indexOf('.') >= 0
+              ? Math.round(f * 18) : Math.round(f);
+          }
+        }
+
         if (json && Array.isArray(json.bgs) && json.bgs.length > 0) {
           var b = json.bgs[0];
-          sgv = parseInt(b.sgv || b.glucose || b.value, 10);
+          sgv = parseSgv(b.sgv || b.glucose || b.value);
           ts = parseInt((b.datetime || b.date || b.mills || b.timestamp || 0), 10);
           trend = b.direction || b.trend || null;
-          bgDelta = parseInt(b.bgdelta, 10);
+          bgDelta = parseDelta(b.bgdelta);
           if (json.status && Array.isArray(json.status) && json.status[0]) {
             serverNow = parseInt(json.status[0].now || 0, 10);
           }
         } else if (Array.isArray(json) && json.length > 0) {
-          sgv = parseInt(json[0].sgv || json[0].glucose || json[0].value, 10);
+          sgv = parseSgv(json[0].sgv || json[0].glucose || json[0].value);
           ts = parseInt((json[0].datetime || json[0].date || json[0].mills || json[0].timestamp || 0), 10);
           trend = json[0].direction || json[0].trend || null;
-          bgDelta = parseInt(json[0].bgdelta, 10);
+          bgDelta = parseDelta(json[0].bgdelta);
         } else if (json && (json.sgv || json.value || json.glucose)) {
-          sgv = parseInt(json.sgv || json.value || json.glucose, 10);
+          sgv = parseSgv(json.sgv || json.value || json.glucose);
           ts = parseInt(json.datetime || json.date || json.mills || json.timestamp || 0, 10);
           trend = json.direction || json.trend || null;
-          bgDelta = parseInt(json.bgdelta, 10);
+          bgDelta = parseDelta(json.bgdelta);
         }
         if (ts && ts > 1000000000000) { // ms -> s
           ts = Math.floor(ts / 1000);
@@ -437,7 +467,7 @@ var keys = require('message_keys');
         if (serverNow && serverNow > 1000000000000) {
           serverNow = Math.floor(serverNow / 1000);
         }
-        if (isFinite(sgv)) {
+        if (isFinite(sgv) && sgv > 0) {
           var nowSec = (serverNow && isFinite(serverNow) && serverNow > 0) ? serverNow : Math.floor(Date.now() / 1000);
           var bgTs = ts || nowSec;
           var ageSec = nowSec - bgTs;
@@ -460,7 +490,7 @@ var keys = require('message_keys');
             'BG_TREND': arrow,
             'BG_UNIT': (config.bgUnit === 'mmol' ? 1 : 0)
           };
-          extras['BG_DELTA'] = isFinite(bgDelta) ? bgDelta : -9999;
+          extras['BG_DELTA'] = (isFinite(bgDelta) && bgDelta !== null) ? bgDelta : -9999;
           sendStatus(status, extras);
           planNextBGFetch(bgTs, nowSec);
         } else {
@@ -500,6 +530,12 @@ var keys = require('message_keys');
           if (cfg.syncBgWithInterval === undefined) cfg.syncBgWithInterval = true;
           if (!cfg.bgManualIntervalMin) cfg.bgManualIntervalMin = 5;
           if (!cfg.bgColor) cfg.bgColor = '#000000';
+          if (cfg.authToken === undefined) cfg.authToken = null;
+          // Migrate old configs: if unit is mmol but thresholds look like mg/dL (>30), convert
+          if (cfg.bgUnit === 'mmol' && cfg.low > 30) {
+            cfg.low  = Math.round(cfg.low  * 10 / 18) / 10;
+            cfg.high = Math.round(cfg.high * 10 / 18) / 10;
+          }
         }
         // Basic sanity: ensure rows exist
         if (cfg && Array.isArray(cfg.rows)) {
@@ -592,6 +628,7 @@ var keys = require('message_keys');
       if (!config.ghostDensity) config.ghostDensity = 3;
       if (config.syncBgWithInterval === undefined) config.syncBgWithInterval = true;
       if (!config.bgManualIntervalMin) config.bgManualIntervalMin = 5;
+      if (config.authToken === undefined) config.authToken = null;
       // Persist to pkjs storage so it survives app restarts
       try { localStorage.setItem('supercgm_config', JSON.stringify(config)); } catch(_e) {}
       sendConfig();

--- a/src/main.c
+++ b/src/main.c
@@ -326,6 +326,7 @@ static void check_bg_alerts(void) {
   if (s_bg_status != BG_STATUS_OK || s_bg_sgv < 0) return;
   time_t now = time(NULL);
   const int cooldown = 600; // 10-minute vibe cooldown
+  // Thresholds and sgv are in the same unit (both ×10 for mmol, both mg/dL for mg/dL)
   if (s_vibe_on_low && s_bg_sgv < s_bg_low) {
     if ((now - s_last_vibe_low_ts) >= cooldown) {
       s_last_vibe_low_ts = now;
@@ -362,7 +363,7 @@ static void layout_rows(void) {
   int16_t gap = 5; // extra spacing between rows on round
 #endif
 #else
-  int16_t y_offset = 0;
+  int16_t y_offset = (bounds.size.h - row_height * ROWS) / 2;
   int16_t gap = 0;
 #endif
   int16_t slot_w = bounds.size.w / 5;
@@ -529,8 +530,8 @@ static void draw_all_rows(void) {
       snprintf(s_bg, sizeof(s_bg), "OLDBG");
     } else {
       if (s_bg_unit_mmol) {
-        int mmol10 = (s_bg_sgv * 10) / 18;
-        snprintf(s_bg, sizeof(s_bg), "%d.%d", mmol10 / 10, mmol10 % 10);
+        // PKJS sends mmol×10 (e.g. 5.9 mmol → 59), display as "X.Y"
+        snprintf(s_bg, sizeof(s_bg), "%d.%d", s_bg_sgv / 10, s_bg_sgv % 10);
       } else {
         snprintf(s_bg, sizeof(s_bg), "%d", s_bg_sgv);
       }
@@ -617,9 +618,12 @@ static void draw_all_rows(void) {
           if (stale_sec < 300) stale_sec = 300;
           if ((int)(now - s_bg_timestamp) > stale_sec) {
             color = GColorLightGray;
-          } else if (s_bg_sgv < s_bg_low) color = s_col_low;
-          else if (s_bg_sgv > s_bg_high) color = s_col_high;
-          else color = s_col_in;
+          } else {
+            // Thresholds and sgv are in the same unit (mmol×10 or mg/dL)
+            if (s_bg_sgv < s_bg_low) color = s_col_low;
+            else if (s_bg_sgv > s_bg_high) color = s_col_high;
+            else color = s_col_in;
+          }
         } else if (s_bg_status == BG_STATUS_NO_CONN || s_bg_status == BG_STATUS_NO_DATA
                    || s_bg_status == BG_STATUS_OLD) {
 #if defined(PBL_COLOR)
@@ -649,7 +653,7 @@ static void draw_all_rows(void) {
           // position overlay near the right
           GRect bounds = get_layout_bounds();
           int16_t row_h = bounds.size.h / ROWS;
-          int16_t y_off = 0;
+          int16_t y_off = (bounds.size.h - row_h * ROWS) / 2; // center rows vertically
           int16_t gap = 0;
 #if defined(PBL_ROUND)
           // Mirror layout_rows() exactly so overlay stays aligned with digit layers
@@ -746,7 +750,7 @@ static void draw_all_rows(void) {
     int16_t slot_w = bounds.size.w / 5;
     int16_t left_pad = (bounds.size.w - slot_w * 5) / 2;
     int deg_slot = 3; // slot before/with unit
-    int16_t y_base = bounds.origin.y + i * row_h;
+    int16_t y_base = bounds.origin.y + (bounds.size.h - row_h * ROWS) / 2 + i * row_h;
     GRect frame = GRect(bounds.origin.x + left_pad + deg_slot * slot_w, y_base, slot_w, row_h);
     s_weather_deg_color = color;
     layer_set_frame(s_weather_deg_layer, frame);
@@ -764,28 +768,35 @@ static void draw_all_rows(void) {
         break;
       case ROW_TYPE_BG_TIMESTAMP: {
         if (s_bg_timestamp > 0) {
-          struct tm *lt = localtime(&s_bg_timestamp);
+          int age_min = (int)((now - s_bg_timestamp) / 60);
+          if (age_min < 0) age_min = 0;
+          if (age_min > 99) age_min = 99;
           char ts[6];
-          snprintf(ts, sizeof(ts), "%02d:%02d", lt->tm_hour, lt->tm_min);
+          if (age_min < 10) {
+            snprintf(ts, sizeof(ts), "%d MIN", age_min); // "5 MIN"
+          } else {
+            snprintf(ts, sizeof(ts), "%dMIN", age_min);  // "10MIN"
+          }
           for (int k = 0; k < 5; k++) slots[k] = ts[k];
         } else {
-          slots[0] = '-';
-          slots[1] = '-';
-          slots[2] = ':';
-          slots[3] = '-';
-          slots[4] = '-';
+          slots[0] = '-'; slots[1] = '-';
+          slots[2] = 'M'; slots[3] = 'I'; slots[4] = 'N';
         }
         break;
       }
       case ROW_TYPE_BG_DELTA: {
         char d[8];
         if (s_bg_status == BG_STATUS_OK && s_bg_delta != -9999) {
-          if (s_bg_delta > 0) {
-            snprintf(d, sizeof(d), "+%d", s_bg_delta);
-          } else if (s_bg_delta < 0) {
-            snprintf(d, sizeof(d), "%d", s_bg_delta);
+          if (s_bg_unit_mmol) {
+            // delta is mmol×10 (e.g. 0.2 mmol → 2), display as "+X.Y"
+            int dabs = s_bg_delta < 0 ? -s_bg_delta : s_bg_delta;
+            if (s_bg_delta > 0)      snprintf(d, sizeof(d), "+%d.%d", dabs/10, dabs%10);
+            else if (s_bg_delta < 0) snprintf(d, sizeof(d), "-%d.%d", dabs/10, dabs%10);
+            else                     snprintf(d, sizeof(d), "+-0");
           } else {
-            snprintf(d, sizeof(d), "+-0");
+            if (s_bg_delta > 0)      snprintf(d, sizeof(d), "+%d", s_bg_delta);
+            else if (s_bg_delta < 0) snprintf(d, sizeof(d), "%d", s_bg_delta);
+            else                     snprintf(d, sizeof(d), "+-0");
           }
         } else {
           snprintf(d, sizeof(d), "--");

--- a/web/config/index.html
+++ b/web/config/index.html
@@ -16,7 +16,7 @@
           <option value="de">Deutsch</option>
         </select>
       </div>
-      <p class="eyebrow" id="heroEyebrow">supercgm-ns v2.0</p>
+      <p class="eyebrow" id="heroEyebrow">supercgm-ns v2.2</p>
       <h1 id="heroTitle">Pick your watch and configure in one go</h1>
       <p class="lede" id="heroLede">Choose your Pebble model to get the right row count (4 for legacy Round, 5 for rectangular and Round 2) and a contrast-safe palette. All colors are quantized so parameters transfer reliably to every Pebble generation.</p>
       <div class="hero-tags">
@@ -138,6 +138,7 @@
         <p id="bgIntro">Only shown when at least one row is set to Nightscout BG. Set URL, timeout, refresh, thresholds, and colors.</p>
       </div>
       <label><span id="bgUrlLabel">Nightscout URL</span> <input type="url" id="bgUrl" placeholder="https://myns.example.com"></label>
+      <label><span id="authTokenLabel">Auth Token (optional)</span> <input type="text" id="authToken" placeholder="yourToken123" autocomplete="off" spellcheck="false"></label>
       <label><span id="bgTimeoutLabel">Timeout (min)</span> <input type="number" id="bgTimeout" value="20" min="5" max="120"></label>
       <label><span id="bgRefreshLabel">BG interval (min)</span> <input type="number" id="bgFetchInt" value="5" min="1" max="180" inputmode="numeric"></label>
       <label><input type="checkbox" id="syncBgWithInterval" checked> <span id="syncBgWithIntervalLabel">Sync with BG interval (timestamp + 30s)</span></label>

--- a/web/config/script.js
+++ b/web/config/script.js
@@ -26,6 +26,7 @@
       bgTitle: 'Nightscout',
       bgIntro: 'Only shown when at least one row is set to Nightscout BG. Set URL, timeout, refresh, thresholds, and colors. Sync mode uses status.now as server time and bgs.datetime as reading time.',
       bgUrlLabel: 'Nightscout URL',
+      authTokenLabel: 'Auth Token (optional)',
       bgTimeoutLabel: 'Timeout (min)',
       bgRefreshLabel: 'BG interval (min)',
       syncBgWithIntervalLabel: 'Sync with BG interval (timestamp + 30s)',
@@ -69,12 +70,12 @@
       bgWhiteLabel: 'White (inverted)',
       rowTypes: {
         0: 'Weather', 1: 'Time', 2: 'Date', 3: 'Weekday', 4: 'Battery',
-        5: 'Nightscout BG', 6: 'Steps', 7: 'Heart Rate', 8: 'BG Time (last)',
+        5: 'Nightscout BG', 6: 'Steps', 7: 'Heart Rate', 8: 'BG Age (min)',
         9: 'BG Delta', 10: 'Rain next 3h'
       },
       shakeTypes: {
         '-1': 'Off', '0': 'Weather', '1': 'Time', '2': 'Date', '3': 'Weekday', '4': 'Battery',
-        '5': 'Nightscout BG', '6': 'Steps', '7': 'Heart Rate', '8': 'BG Time (last)',
+        '5': 'Nightscout BG', '6': 'Steps', '7': 'Heart Rate', '8': 'BG Age (min)',
         '9': 'BG Delta', '10': 'Rain next 3h'
       },
       presets: {
@@ -110,6 +111,7 @@
       bgTitle: 'Nightscout',
       bgIntro: 'Wird nur angezeigt, wenn mindestens eine Zeile Nightscout BG nutzt. URL, Timeout, Intervall, Grenzwerte und Farben setzen. Sync nutzt status.now als Serverzeit und bgs.datetime als Messzeit.',
       bgUrlLabel: 'Nightscout-URL',
+      authTokenLabel: 'Auth-Token (optional)',
       bgTimeoutLabel: 'Timeout (Min)',
       bgRefreshLabel: 'BG-Intervall (Min)',
       syncBgWithIntervalLabel: 'Mit BG-Intervall synchronisieren (Timestamp + 30s)',
@@ -153,12 +155,12 @@
       bgWhiteLabel: 'Weiss (invertiert)',
       rowTypes: {
         0: 'Wetter', 1: 'Uhrzeit', 2: 'Datum', 3: 'Wochentag', 4: 'Batterie',
-        5: 'Nightscout BG', 6: 'Schritte', 7: 'Puls', 8: 'BG-Zeit (letzter)',
+        5: 'Nightscout BG', 6: 'Schritte', 7: 'Puls', 8: 'BG-Alter (min)',
         9: 'BG-Delta', 10: 'Regen naechste 3h'
       },
       shakeTypes: {
         '-1': 'Aus', '0': 'Wetter', '1': 'Uhrzeit', '2': 'Datum', '3': 'Wochentag', '4': 'Batterie',
-        '5': 'Nightscout BG', '6': 'Schritte', '7': 'Puls', '8': 'BG-Zeit (letzter)',
+        '5': 'Nightscout BG', '6': 'Schritte', '7': 'Puls', '8': 'BG-Alter (min)',
         '9': 'BG-Delta', '10': 'Regen naechste 3h'
       },
       presets: {
@@ -338,8 +340,66 @@
     defaultRows: [],
     defaultBgColors: {},
     lang: 'en',
-    previewMode: 'main'
+    previewMode: 'main',
+    thresholdUnit: 'mgdl'  // tracks what unit the threshold inputs currently show
   };
+
+  // ── Threshold unit helpers ──────────────────────────────────────────────
+  function mgdlToMmol(mgdl) {
+    return Math.round(parseFloat(mgdl) * 10 / 18) / 10;
+  }
+  function mmolToMgdl(mmol) {
+    return Math.round(parseFloat(mmol) * 18);
+  }
+  function setThresholdInputAttr(unit) {
+    var lowEl = byId('low'), highEl = byId('high');
+    if (!lowEl || !highEl) return;
+    if (unit === 'mmol') {
+      lowEl.step  = '0.1'; lowEl.min  = '1';  lowEl.max  = '33';
+      highEl.step = '0.1'; highEl.min = '1';  highEl.max = '33';
+    } else {
+      lowEl.step  = '1';   lowEl.min  = '40'; lowEl.max  = '400';
+      highEl.step = '1';   highEl.min = '40'; highEl.max = '400';
+    }
+    updateThresholdUnitLabels(unit);
+  }
+  // Takes stored mg/dL values, displays them in the currently active unit.
+  function setThresholdValues(mgdlLow, mgdlHigh) {
+    var unit = document.querySelector('input[name="bgunit"]:checked');
+    var u = unit ? unit.value : 'mgdl';
+    var lowEl = byId('low'), highEl = byId('high');
+    if (!lowEl || !highEl) return;
+    if (u === 'mmol') {
+      lowEl.value  = mgdlToMmol(mgdlLow).toFixed(1);
+      highEl.value = mgdlToMmol(mgdlHigh).toFixed(1);
+    } else {
+      lowEl.value  = mgdlLow;
+      highEl.value = mgdlHigh;
+    }
+    state.thresholdUnit = u;
+    setThresholdInputAttr(u);
+  }
+  function updateThresholdUnitLabels(unit) {
+    var unitStr = unit === 'mmol' ? ' (mmol/L)' : ' (mg/dL)';
+    var lo = byId('lowLabel'), hi = byId('highLabel');
+    if (lo) lo.textContent = txt('lowLabel') + unitStr;
+    if (hi) hi.textContent = txt('highLabel') + unitStr;
+  }
+  // Called when bgunit radio changes; converts current threshold values to the new unit.
+  function onBgUnitChange() {
+    var newUnit = (document.querySelector('input[name="bgunit"]:checked') || {}).value || 'mgdl';
+    if (newUnit === state.thresholdUnit) return;
+    var lowEl = byId('low'), highEl = byId('high');
+    if (!lowEl || !highEl) return;
+    var curLow = parseFloat(lowEl.value) || 0;
+    var curHigh = parseFloat(highEl.value) || 0;
+    // Convert from old display unit to mg/dL, then re-display in new unit
+    var mgdlLow  = state.thresholdUnit === 'mmol' ? mmolToMgdl(curLow)  : Math.round(curLow);
+    var mgdlHigh = state.thresholdUnit === 'mmol' ? mmolToMgdl(curHigh) : Math.round(curHigh);
+    state.thresholdUnit = newUnit;
+    setThresholdValues(mgdlLow, mgdlHigh);
+  }
+  // ── End threshold helpers ───────────────────────────────────────────────
 
   function getLang() {
     var q = (params.lang || '').toLowerCase();
@@ -410,13 +470,13 @@
     setText('bgTitle', txt('bgTitle'));
     setText('bgIntro', txt('bgIntro'));
     setText('bgUrlLabel', txt('bgUrlLabel'));
+    setText('authTokenLabel', txt('authTokenLabel'));
     setText('bgTimeoutLabel', txt('bgTimeoutLabel'));
     setText('bgRefreshLabel', txt('bgRefreshLabel'));
     setText('syncBgWithIntervalLabel', txt('syncBgWithIntervalLabel'));
     setText('bgManualLabel', txt('bgManualLabel'));
     setText('cgmUnitLabel', txt('cgmUnitLabel'));
-    setText('lowLabel', txt('lowLabel'));
-    setText('highLabel', txt('highLabel'));
+    updateThresholdUnitLabels(state.thresholdUnit);
     setText('colorLowLabel', txt('colorLowLabel'));
     setText('colorInLabel', txt('colorInLabel'));
     setText('colorHighLabel', txt('colorHighLabel'));
@@ -587,7 +647,7 @@
       case 5: return toSlots5(' 118 ');
       case 6: return toSlots5(' 7420');
       case 7: return toSlots5('HR072');
-      case 8: return toSlots5(' 1328');
+      case 8: return toSlots5(' 5MIN');
       case 9: return toSlots5(' +12');
       case 10: return toSlots5('R 40%');
       default: return toSlots5('     ');
@@ -1388,10 +1448,11 @@
       syncBgWithInterval: byId('syncBgWithInterval').checked,
       bgManualIntervalMin: parseInt(byId('bgManualInt').value,10),
       bgUrl: byId('bgUrl').value.trim(),
+      authToken: (byId('authToken').value || '').trim() || null,
       bgTimeoutMin: parseInt(byId('bgTimeout').value,10),
       bgUnit: document.querySelector('input[name="bgunit"]:checked').value,
-      low: parseInt(byId('low').value,10),
-      high: parseInt(byId('high').value,10),
+      low:  parseFloat(byId('low').value)  || 0,
+      high: parseFloat(byId('high').value) || 0,
       colors: {
         low: colLow,
         in: colIn,
@@ -1451,14 +1512,26 @@
       document.querySelector('input[name="tempunit"][value="'+(cfg.tempUnit||'C')+'"]').checked = true;
       byId('weatherInt').value = cfg.weatherIntervalMin || 30;
       byId('bgUrl').value = cfg.bgUrl || '';
+      if (byId('authToken')) byId('authToken').value = cfg.authToken || '';
       byId('bgTimeout').value = cfg.bgTimeoutMin || 20;
       byId('bgFetchInt').value = cfg.bgFetchIntervalMin || 5;
       byId('syncBgWithInterval').checked = cfg.syncBgWithInterval !== false;
       byId('bgManualInt').value = cfg.bgManualIntervalMin || 5;
       updateBGFetchModeUI();
       document.querySelector('input[name="bgunit"][value="'+(cfg.bgUnit||'mgdl')+'"]').checked = true;
-      byId('low').value = cfg.low || 80;
-      byId('high').value = cfg.high || 180;
+      var savedLow = cfg.low || 80, savedHigh = cfg.high || 180;
+      var savedUnit = cfg.bgUnit || 'mgdl';
+      // Migrate old configs that stored mg/dL values while unit was mmol
+      if (savedUnit === 'mmol' && savedLow > 30) {
+        savedLow  = mgdlToMmol(savedLow);
+        savedHigh = mgdlToMmol(savedHigh);
+      }
+      // setThresholdValues takes mg/dL and converts; but values are already in savedUnit here.
+      // Directly set inputs and attributes for the saved unit.
+      state.thresholdUnit = savedUnit;
+      byId('low').value   = savedUnit === 'mmol' ? parseFloat(savedLow).toFixed(1)  : savedLow;
+      byId('high').value  = savedUnit === 'mmol' ? parseFloat(savedHigh).toFixed(1) : savedHigh;
+      setThresholdInputAttr(savedUnit);
       var applyColorValue = function(id, value) {
         var input = byId(id);
         var sel = byId(id + 'Fallback');
@@ -1524,6 +1597,8 @@
     rebuildColorPickers();
     updateBgColorUI();
     restoreSaved();
+    // Ensure threshold inputs have correct attributes after restore
+    setThresholdInputAttr(state.thresholdUnit);
     updateDeviceNote();
     byId('rows-form').addEventListener('change', function(e){
       if (e.target && (e.target.classList.contains('row-type'))) updateBGSectionVisibility();
@@ -1577,6 +1652,10 @@
     }
     var bwOpts = byId('bgBwOptions');
     if (bwOpts) bwOpts.addEventListener('change', swapBWRowColors);
+    // Convert threshold inputs when BG unit is changed
+    document.querySelectorAll('input[name="bgunit"]').forEach(function(r){
+      r.addEventListener('change', onBgUnitChange);
+    });
     var reloadBtn = byId('reload');
     if (reloadBtn) reloadBtn.onclick = reloadLatest;
     var langChooser = byId('langChooser');


### PR DESCRIPTION
…is centering

- Fix #29: mmol SGV/delta now sent as ×10 integer from JS, displayed as X.Y on watch (no more parseInt precision loss)
- Fix #28: Nightscout auth token support — appended as ?token= to /pebble URL
- Fix #27: BG timestamp shows minutes ago ("5 MIN" / "10MIN") instead of clock time; Y-axis rows centered on Pebble Time 2
- Thresholds natively stored and sent in user's configured unit (mmol or mg/dL); migration for old configs
- Config UI: threshold inputs switch step/min/max on unit change, live label updates, auth token field
- Version bumped to 2.2